### PR TITLE
Added basic devise support.

### DIFF
--- a/app/controllers/dashing/application_controller.rb
+++ b/app/controllers/dashing/application_controller.rb
@@ -1,7 +1,15 @@
 module Dashing
   class ApplicationController < ActionController::Base
 
+    before_filter :authentication_with_devise
+
     private
+
+    def authentication_with_devise
+      Dashing.config.devise_allowed_models.each do |model|
+        self.send('authenticate_'+model.downcase+'!')
+      end
+    end
 
     def check_accessibility
       auth_token = params.delete(:auth_token)

--- a/lib/dashing/configuration.rb
+++ b/lib/dashing/configuration.rb
@@ -6,20 +6,21 @@ module Dashing
 
     attr_accessor :scheduler, :redis, :view_path, :jobs_path, :redis_namespace,
                   :engine_path, :dashboards_path, :dashboard_layout,
-                  :widgets_path, :default_dashboard, :auth_token
+                  :widgets_path, :default_dashboard, :auth_token, :devise_allowed_models
 
     def initialize
-      @scheduler          = ::Rufus::Scheduler.new
-      @redis              = ::Redis.new
-      @redis_namespace    = 'dashing_events'
-      @view_path          = 'app/views/dashing/'
-      @jobs_path          = 'app/jobs/'
-      @engine_path        = '/dashing'
-      @dashboards_path    = 'app/views/dashing/dashboards/'
-      @dashboard_layout   = 'dashing/dashboard'
-      @widgets_path       = 'app/views/dashing/widgets/'
-      @default_dashboard  = nil
-      @auth_token         = nil
+      @scheduler              = ::Rufus::Scheduler.new
+      @redis                  = ::Redis.new
+      @redis_namespace        = 'dashing_events'
+      @view_path              = 'app/views/dashing/'
+      @jobs_path              = 'app/jobs/'
+      @engine_path            = '/dashing'
+      @dashboards_path        = 'app/views/dashing/dashboards/'
+      @dashboard_layout       = 'dashing/dashboard'
+      @widgets_path           = 'app/views/dashing/widgets/'
+      @default_dashboard      = nil
+      @auth_token             = nil
+      @devise_allowed_models  = []
     end
 
   end

--- a/lib/generators/templates/initializer.rb
+++ b/lib/generators/templates/initializer.rb
@@ -47,4 +47,8 @@ Dashing.configure do |config|
   # Put nil if you don't want to use authentication.
   # You can use SecureRandom.hex to generate a hex.
   # config.auth_token = nil
+
+  # List of Devise models that should access the whole dashboard.
+  # List the models. E.g: '[ "User", "Admin" ]'
+  # config.devise_allowed_models = []
 end


### PR DESCRIPTION
I'm using devise for authentication. Sinatra app uses protected! method, but I can't see it in this port. So, I decided to add a basic configuration for devise. It asks for the model names that needs access to dashing controllers. If an empty array is used (default) we will not use devise methods.
