### PR TITLE
Use protocol agnostic URL for Google's font

### DIFF
--- a/app/views/layouts/dashing/dashboard.html.erb
+++ b/app/views/layouts/dashing/dashboard.html.erb
@@ -11,7 +11,7 @@
     <%= javascript_include_tag 'dashing/application' %>
     <%= stylesheet_link_tag 'dashing/application' %>
 
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
     <link rel="icon" href="/favicon.ico">
   </head>
   <body>


### PR DESCRIPTION
HTTPS users are happy now :)

I've already done this in dashing itself ;)
See Shopify/dashing#107
