### PR TITLE
Fixes background icon alignment

### DIFF
--- a/vendor/assets/stylesheets/dashing/dashing-src.scss
+++ b/vendor/assets/stylesheets/dashing/dashing-src.scss
@@ -120,6 +120,7 @@ h3 {
   top: 0;
   opacity: 0.1;
   font-size: 275px;
+  text-align: center;
 }
 
 .list-nostyle {


### PR DESCRIPTION
Since some version of FontAwesome I don't recall, this center alignment is needed so the icons show centered on the container. I guess that when you forked the original dashing, you updated FontAwesome, but didn't apply this css fix.  The original Dashing repository applied this fix some time ago: https://github.com/Shopify/dashing/commit/3af326da84251069c4e6f7464d0ae8506b20e98b#diff-c05224104d6cdd7a84efb7ae4e8fd074L119
