### PR TITLE
Use Rails.root.join without lambdas to declare dashboards_views_path and jobs_path inside configuration.rb

### DIFF
--- a/app/controllers/dashing/dashboards_controller.rb
+++ b/app/controllers/dashing/dashboards_controller.rb
@@ -20,7 +20,7 @@ module Dashing
     end
 
     def dashboard_path(name)
-      Dashing.config.dashboards_views_path.call.join(name)
+      Dashing.config.dashboards_views_path.join(name)
     end
 
     def template_not_found

--- a/lib/dashing.rb
+++ b/lib/dashing.rb
@@ -14,7 +14,7 @@ module Dashing
     end
 
     def first_dashboard
-      files = Dir[config.dashboards_views_path.call.join('*')].collect { |f| File.basename(f, '.*') }
+      files = Dir[config.dashboards_views_path.join('*')].collect { |f| File.basename(f, '.*') }
       files.sort.first
     end
 

--- a/lib/dashing/configuration.rb
+++ b/lib/dashing/configuration.rb
@@ -29,11 +29,11 @@ module Dashing
       @devise_allowed_models  = []
 
       # Jobs
-      @jobs_path              = -> { Rails.root.join('app', 'jobs') }
+      @jobs_path              = Rails.root.join('app', 'jobs')
 
       # Dashboards
       @default_dashboard      = nil
-      @dashboards_views_path  = -> { Rails.root.join('app', 'views', 'dashing', 'dashboards') }
+      @dashboards_views_path  = Rails.root.join('app', 'views', 'dashing', 'dashboards')
       @dashboard_layout_path  = 'dashing/dashboard'
 
       # Widgets

--- a/lib/dashing/railtie.rb
+++ b/lib/dashing/railtie.rb
@@ -14,7 +14,7 @@ module Dashing
     end
 
     initializer 'require dashing jobs' do
-      Dir[Dashing.config.jobs_path.call.join('**', '*.rb')].each { |file| require file }
+      Dir[Dashing.config.jobs_path.join('**', '*.rb')].each { |file| require file }
     end
 
     initializer 'fix redis child connection' do

--- a/lib/generators/templates/initializer.rb
+++ b/lib/generators/templates/initializer.rb
@@ -27,19 +27,19 @@ Dashing.configure do |config|
   #
   # You can change default views and assets paths with the following config:
   #
-  # config.widgets_views_path = -> { Rails.root.join('app', 'views', 'dashing', 'widgets') }
-  # config.widgets_js_path    = 'app/assets/javascripts/dashing'
-  # config.widgets_css_path   = 'app/assets/stylesheets/dashing'
+  # config.widgets_views_path = Rails.root.join('app', 'views', 'dashing', 'widgets')
+  # config.widgets_js_path    = Rails.root.join('app', 'assets', 'javascripts', 'dashing')
+  # config.widgets_css_path   = Rails.root.join('app', 'assets', 'stylesheets', 'dashing')
 
   # rufus-scheduler worker path
-  # config.jobs_path = -> { Rails.root.join('app', 'jobs') }
+  # config.jobs_path = Rails.root.join('app', 'jobs')
 
   # Engine path to use for accessing engine's routes.
   # Ex: http://your_app/dashing/dashboard/my_dashboard_name
   # config.engine_path = '/dashing'
 
   # The dashboards views path used to find dashboards.
-  # config.dashboards_views_path = -> { Rails.root.join('app', 'views', 'dashing', 'dashboards') }
+  # config.dashboards_views_path = Rails.root.join('app', 'views', 'dashing', 'dashboards')
 
   # The Dashing layout used to display metrics.
   # config.dashboard_layout_path = 'dashing/dashboard'

--- a/spec/dummy/config/initializers/dashing.rb
+++ b/spec/dummy/config/initializers/dashing.rb
@@ -32,7 +32,7 @@ Dashing.configure do |config|
   # config.widgets_css_path   = 'app/assets/stylesheets/dashing'
 
   # rufus-scheduler worker path
-  # config.jobs_path = 'app/jobs/'
+  # config.jobs_path = Rails.root.join('app', 'jobs')
 
   # Engine path to use for accessing engine's routes.
   # Ex: http://your_app/dashing/dashboard/my_dashboard_name

--- a/spec/lib/dashing/configuration_spec.rb
+++ b/spec/lib/dashing/configuration_spec.rb
@@ -20,11 +20,11 @@ describe Dashing::Configuration do
   it { expect(instance.devise_allowed_models).to  be_empty }
 
   # Jobs
-  it { expect(instance.jobs_path.call.to_s).to    include('app/jobs') }
+  it { expect(instance.jobs_path.to_s).to    include('app/jobs') }
 
   # Dashboards
   it { expect(instance.default_dashboard).to      be_nil }
-  it { expect(instance.dashboards_views_path.call.to_s).to include('app/views/dashing/dashboards') }
+  it { expect(instance.dashboards_views_path.to_s).to include('app/views/dashing/dashboards') }
   it { expect(instance.dashboard_layout_path).to  eq('dashing/dashboard') }
 
   # Widgets


### PR DESCRIPTION
This is continuation of #52. 
#52 fixed issue when `Rails.root` was not initialized during invocation of `Configuration` initializer. Because of that we can switch to using `Rails.root` for initializing of `dashboards_views_path` and `jobs_path` config options.

Best wishes, 
Alex L.
