### PR TITLE
Use connection pool without wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,11 @@ dashing_events.*
 where `*` can be anything. This give you all the flexibility you need to push to redis. For example the `send_event` method provided by Dashing uses the following namespace:
 
 ```ruby
-redis.publish("dashing_events.create", {})
+redis.with do |redis_connection|
+  redis_connection.publish("dashing_events.create", {})
+end
 ```
+(where `redis_connection` is a redis connection from a connection pooler.)
 
 You can configure the redis namespace in `config/initializers/dashing.rb`:
 

--- a/app/controllers/dashing/events_controller.rb
+++ b/app/controllers/dashing/events_controller.rb
@@ -19,9 +19,7 @@ module Dashing
     rescue IOError
       logger.info "[Dashing][#{Time.now.utc.to_s}] Stream closed"
     ensure
-      @redis.shutdown do |redis_connection|
-        redis_connection.quit
-      end
+      @redis.shutdown { |redis_connection| redis_connection.quit }
       response.stream.close
     end
 

--- a/app/controllers/dashing/events_controller.rb
+++ b/app/controllers/dashing/events_controller.rb
@@ -3,26 +3,33 @@ module Dashing
     include ActionController::Live
 
     def index
+      @redis = Dashing.redis
+
       response.headers['Content-Type']      = 'text/event-stream'
       response.headers['X-Accel-Buffering'] = 'no'
       response.stream.write latest_events
 
-      @redis = Dashing.redis
-      @redis.psubscribe("#{Dashing.config.redis_namespace}.*") do |on|
-        on.pmessage do |pattern, event, data|
-          response.stream.write("data: #{data}\n\n")
+      @redis.with do |redis_connection|
+        redis_connection.psubscribe("#{Dashing.config.redis_namespace}.*") do |on|
+          on.pmessage do |pattern, event, data|
+            response.stream.write("data: #{data}\n\n")
+          end
         end
       end
     rescue IOError
       logger.info "[Dashing][#{Time.now.utc.to_s}] Stream closed"
     ensure
-      @redis.quit
+      @redis.shutdown do |redis_connection|
+        redis_connection.quit
+      end
       response.stream.close
     end
 
     def latest_events
-      events = Dashing.redis.hvals("#{Dashing.config.redis_namespace}.latest")
-      events.map { |v| "data: #{v}\n\n" }.join
+      @redis.with do |redis_connection|
+        events = redis_connection.hvals("#{Dashing.config.redis_namespace}.latest")
+        events.map { |v| "data: #{v}\n\n" }.join
+      end
     end
   end
 end

--- a/app/controllers/dashing/widgets_controller.rb
+++ b/app/controllers/dashing/widgets_controller.rb
@@ -14,7 +14,9 @@ module Dashing
     def update
       data = params[:widget] || {}
       hash = data.merge(id: params[:name], updatedAt: Time.now.utc.to_i)
-      Dashing.redis.publish("#{Dashing.config.redis_namespace}.create", hash.to_json)
+      Dashing.redis.with do |redis_connection|
+        redis_connection.publish("#{Dashing.config.redis_namespace}.create", hash.to_json)
+      end
 
       render nothing: true
     end

--- a/lib/dashing.rb
+++ b/lib/dashing.rb
@@ -20,8 +20,10 @@ module Dashing
 
     def send_event(id, data)
       event = data.merge(id: id, updatedAt: Time.now.utc.to_i).to_json
-      redis.hset("#{Dashing.config.redis_namespace}.latest", id, event)
-      redis.publish("#{Dashing.config.redis_namespace}.create", event)
+      redis.with do |redis_connection|
+        redis_connection.hset("#{Dashing.config.redis_namespace}.latest", id, event)
+        redis_connection.publish("#{Dashing.config.redis_namespace}.create", event)
+      end
     end
 
   end

--- a/lib/dashing/configuration.rb
+++ b/lib/dashing/configuration.rb
@@ -43,7 +43,7 @@ module Dashing
     end
 
     def redis
-      @redis ||= ::ConnectionPool::Wrapper.new(size: request_thread_count, timeout: redis_timeout) { new_redis_connection }
+      @redis ||= ::ConnectionPool.new(size: request_thread_count, timeout: redis_timeout) { new_redis_connection }
     end
 
     def new_redis_connection

--- a/lib/dashing/railtie.rb
+++ b/lib/dashing/railtie.rb
@@ -21,8 +21,10 @@ module Dashing
       if defined?(::PhusionPassenger)
         ::PhusionPassenger.on_event(:starting_worker_process) do |forked|
           if forked
-            ::Dashing.redis.client.disconnect
-            ::Dashing.redis.client.connect
+            ::Dashing.redis.with do |redis_connection|
+              redis_connection.client.disconnect
+              redis_connection.client.connect
+            end
           end
         end
       end

--- a/spec/controllers/dashing/widgets_controller_spec.rb
+++ b/spec/controllers/dashing/widgets_controller_spec.rb
@@ -1,9 +1,10 @@
 RSpec.describe Dashing::WidgetsController do
 
   let(:redis) { double }
+  let(:redis_connection) { double }
 
   before do
-    stub_redis(redis)
+    stub_redis_with_connection(redis, redis_connection)
     @routes = Dashing::Engine.routes
   end
 
@@ -49,7 +50,7 @@ RSpec.describe Dashing::WidgetsController do
     context 'when valid' do
 
       before do
-        expect(redis).to receive(:publish)
+        expect(redis_connection).to receive(:publish)
       end
 
       it 'responds success' do

--- a/spec/lib/dashing/configuration_spec.rb
+++ b/spec/lib/dashing/configuration_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Dashing::Configuration do
   it { expect(instance.engine_path).to            eq('/dashing') }
   # it { expect(instance.scheduler).to              be_a(::Rufus::Scheduler.new) }
   it { expect(instance.redis).to                  be_a(::ConnectionPool) }
-  it { instance.redis.with {|r| expect(r).to      be_a(::Redis)} }
+  it { instance.redis.with { |r| expect(r).to     be_a(::Redis) } }
 
   # Redis
   it { expect(instance.redis_host).to             eq('127.0.0.1') }

--- a/spec/lib/dashing/configuration_spec.rb
+++ b/spec/lib/dashing/configuration_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Dashing::Configuration do
 
   it { expect(instance.engine_path).to            eq('/dashing') }
   # it { expect(instance.scheduler).to              be_a(::Rufus::Scheduler.new) }
-  it { expect(instance.redis).to                  be_a(::Redis) }
+  it { expect(instance.redis).to                  be_a(::ConnectionPool) }
+  it { instance.redis.with {|r| expect(r).to      be_a(::Redis)} }
 
   # Redis
   it { expect(instance.redis_host).to             eq('127.0.0.1') }

--- a/spec/support/controller_spec_helpers.rb
+++ b/spec/support/controller_spec_helpers.rb
@@ -6,4 +6,9 @@ module ControllerSpecHelpers
   def stub_redis(stubbed_redis)
     allow(Dashing.config).to receive(:redis).and_return(stubbed_redis)
   end
+
+  def stub_redis_with_connection(stubbed_redis, stubbed_redis_connection)
+    stub_redis(stubbed_redis)
+    allow(stubbed_redis).to receive(:with).and_yield(stubbed_redis_connection)
+  end
 end


### PR DESCRIPTION
Per the [**connection_pool**](https://github.com/mperham/connection_pool) documentation, using `ConnectionPool::Wrapper` is not performant and has been replaced by `with` on a connection pool to obtain a connection. This PR is a rough-and-ready switch over to using the new `ConnectionPool.new` instead of the old, temporary `ConnectionPool::Wrapper.new`.

This may address some issues where redis connections are not being released: https://github.com/gottfrois/dashing-rails/issues/94, https://github.com/gottfrois/dashing-rails/issues/60.

Followed https://github.com/mperham/connection_pool#migrating-to-a-connection-pool to make the changes.