### PR TITLE
Fix ConnectionPool::PoolShuttingDownError and Rails 5.2 integration

### DIFF
--- a/app/controllers/dashing/events_controller.rb
+++ b/app/controllers/dashing/events_controller.rb
@@ -19,7 +19,7 @@ module Dashing
     rescue IOError
       logger.info "[Dashing][#{Time.now.utc.to_s}] Stream closed"
     ensure
-      #@redis.shutdown { |redis_connection| redis_connection.quit }
+      # @redis.shutdown { |redis_connection| redis_connection.quit }
       response.stream.close
     end
 

--- a/app/controllers/dashing/events_controller.rb
+++ b/app/controllers/dashing/events_controller.rb
@@ -19,7 +19,7 @@ module Dashing
     rescue IOError
       logger.info "[Dashing][#{Time.now.utc.to_s}] Stream closed"
     ensure
-      @redis.shutdown { |redis_connection| redis_connection.quit }
+      #@redis.shutdown { |redis_connection| redis_connection.quit }
       response.stream.close
     end
 

--- a/app/controllers/dashing/events_controller.rb
+++ b/app/controllers/dashing/events_controller.rb
@@ -8,19 +8,22 @@ module Dashing
       response.headers['Content-Type']      = 'text/event-stream'
       response.headers['X-Accel-Buffering'] = 'no'
       response.stream.write latest_events
-
-      @redis.with do |redis_connection|
-        redis_connection.psubscribe("#{Dashing.config.redis_namespace}.*") do |on|
-          on.pmessage do |pattern, event, data|
-            response.stream.write("data: #{data}\n\n")
+      
+      begin        
+        @redis.with do |redis_connection|
+          redis_connection.psubscribe("#{Dashing.config.redis_namespace}.*") do |on|
+            on.pmessage do |pattern, event, data|
+              response.stream.write("data: #{data}\n\n")
+            end
           end
         end
+      rescue IOError, ActionController::Live::ClientDisconnected
+        logger.info "[Dashing][#{Time.now.utc.to_s}] Stream closed"
+        @redis.shutdown { |redis_connection| redis_connection.quit }
+      ensure
+        # @redis.shutdown { |redis_connection| redis_connection.quit }
+        response.stream.close
       end
-    rescue IOError
-      logger.info "[Dashing][#{Time.now.utc.to_s}] Stream closed"
-    ensure
-      #@redis.shutdown { |redis_connection| redis_connection.quit }
-      response.stream.close
     end
 
     def latest_events

--- a/dashing.gemspec
+++ b/dashing.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rails',                      '>= 4.0'
   spec.add_dependency 'jquery-rails',               '>= 3.0'
   spec.add_dependency 'coffee-script',              '>= 2.0'
-  spec.add_dependency 'rufus-scheduler',            '~> 3.2'
+  spec.add_dependency 'rufus-scheduler',            '~> 3.5'
   spec.add_dependency 'redis',                      '~> 3.2'
   spec.add_dependency 'connection_pool',            '~> 2.2'
 


### PR DESCRIPTION
Using Rails 5.2 with dashing-rails engine and puma as server the following exception is raised :

When 2 instances of the dashboard is running in different brownser when one of them is closed it close the global connection and the exception is raised

`{ 47396901434900 rufus-scheduler intercepted an error:
web_1    |   47396901434900   job:
web_1    |   47396901434900     Rufus::Scheduler::EveryJob "2s" {}
web_1    |   47396901434900   error:
web_1    |   47396901434900     47396901434900
web_1    |   47396901434900     ConnectionPool::PoolShuttingDownError
web_1    |   47396901434900     ConnectionPool::PoolShuttingDownError`
